### PR TITLE
Add prepack script

### DIFF
--- a/packages/micro-image-image/package.json
+++ b/packages/micro-image-image/package.json
@@ -13,7 +13,8 @@
     "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
     "lint": "eslint \"src/**/*.ts*\"",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
+    "prepack": "yarn build"
   },
   "devDependencies": {
     "@micro-image/tsconfig": "*",


### PR DESCRIPTION
Allows the package to be installed directly from the repository. Tested by adding the below line into my package.json and importing the files.
```json
    "@micro-image/image": "git@github.com:SagnikPradhan/micro-image.git#workspace=@micro-image/image",
```
